### PR TITLE
Support blocking Monix tasks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['8', '11', '17']
-        scala: ['2.12.15', '2.13.8', '3.1.1']
+        scala: ['2.12.17', '2.13.10', '3.1.3']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.0.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.8.0


### PR DESCRIPTION
Add support from running Monix tasks on ZIO's blocking executor.

Also add some convenience methods that provide a Monix scheduler that can be used to construct Monix tasks.