### PR TITLE
Don't use fiber.unsafe.addObserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
   push:
     branches:
-      - 'master'
-      - 'series/2.x'
+      - "master"
+      - "series/2.x"
   release:
     types:
       - published
@@ -40,8 +40,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8', '11', '17']
-        scala: ['2.12.17', '2.13.10', '3.1.3']
+        java: ["8", "11", "17"]
+        scala: ["2.12.17", "2.13.10", "3.2.1"]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.0.0

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val root = project
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library")
   )
 
-val zioVersion = "2.0.0"
+val zioVersion = "2.0.6"
 
 lazy val interopMonix = crossProject(JSPlatform, JVMPlatform)
   .in(file("interop-monix"))

--- a/interop-monix/shared/src/test/scala/zio/interop/monix/MonixTaskSpec.scala
+++ b/interop-monix/shared/src/test/scala/zio/interop/monix/MonixTaskSpec.scala
@@ -109,13 +109,13 @@ object MonixTaskSpec extends ZIOSpecDefault {
             result  <- ZIO.fromMonixTask(monixTask)
             current <- ZIO.succeed(testVar)
           } yield assertTrue(result == 0) && assertTrue(current == result + 1)
-        },
+        } @@ nonFlaky,
         test("converts a failed ZIO task to a failed Monix task") {
           val error = new Exception("ZIO operation failed")
           val io    = ZIO.fail(error)
           val test  = io.toMonixTask.flatMap[Any, Throwable, Nothing](ZIO.fromMonixTask(_)).either
           assertZIO(test)(isLeft(equalTo(error)))
-        },
+        } @@ nonFlaky,
         test("propagates cancellation from Monix to ZIO") {
           @volatile var cancelled = false
           @volatile var running   = false

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -25,7 +25,7 @@ object BuildHelper {
 
   val Scala212: String = versions("2.12")
   val Scala213: String = versions("2.13")
-  val Scala3: String   = versions("3.1")
+  val Scala3: String   = versions("3.2")
 
   private val stdOptions = Seq(
     "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.0
+sbt.version = 1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"                %
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"          % "3.0.2")
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"                % "5.6.5")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"  % "1.2.0")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"               % "1.10.0")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"               % "1.12.0")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                  % "2.3.2")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"              % "2.4.6")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                   % "0.4.3")


### PR DESCRIPTION
I've observed very rare cases where when converting a ZIO workflow to a Monix task, that the execution hangs, probably because the Monix callback isn't being invoked. It seems that adding an observer to a fiber that is already runninng may not be 100% reliable, but there's currently no accesible API to create a fiber without also starting it.

Instead of adding an observer to the fiber via the unsafe API, this adds an `onExit` handler to the underlying ZIO workflow, which can then invoke the Monix callback.