### PR TITLE
Removes Usages of ZIO.succeedNow

### DIFF
--- a/interop-monix/shared/src/main/scala/zio/interop/monix/package.scala
+++ b/interop-monix/shared/src/main/scala/zio/interop/monix/package.scala
@@ -58,7 +58,7 @@ package object monix {
         monixTask.runSyncStep match {
           case Right(result)        =>
             // Monix task ran synchronously and successfully
-            Right(ZIO.succeedNow(result))
+            Right(ZIO.succeed(result))
           case Left(asyncMonixTask) =>
             // Monix task hit an async boundary, so we have to use the callback (cb)
             // and return a cancelation effect


### PR DESCRIPTION
This is an internal API and will be deleted.